### PR TITLE
fix arguments for MSMS computation

### DIFF
--- a/masif/source/data_preparation/01-pdb_extract_and_triangulate.py
+++ b/masif/source/data_preparation/01-pdb_extract_and_triangulate.py
@@ -84,7 +84,7 @@ out_filename1 = tmp_dir+"/"+pdb_id+"_"+chain_ids1
 extractPDB(pdb_filename, out_filename1+".pdb", chain_ids1, ligand_code, ligand_chain)
 
 # Compute MSMS of surface w/hydrogens,
-vertices1, faces1, normals1, names1, areas1 = computeMSMS(out_filename1+".pdb", protonate=True, ligand_code=ligand_code)
+vertices1, faces1, normals1, names1, areas1 = computeMSMS(out_filename1+".pdb", protonate=True, keep_hetatms=[ligand_code])
 
 # Get and RDKit molecule object
 if ligand_code is not None and ligand_chain is not None:
@@ -133,7 +133,7 @@ if masif_opts['use_apbs']:
 iface = np.zeros(len(regular_mesh.vertices))
 if 'compute_iface' in masif_opts and masif_opts['compute_iface']:
     # Compute the surface of the entire complex and from that compute the interface.
-    v3, f3, _, _, _ = computeMSMS(pdb_filename, protonate=True, ligand_code=ligand_code)
+    v3, f3, _, _, _ = computeMSMS(pdb_filename, protonate=True, keep_hetatms=[ligand_code])
     # Regularize the mesh
     mesh = pymesh.form_mesh(v3, f3)
     # I believe It is not necessary to regularize the full mesh. This can speed up things by a lot.

--- a/masif/source/triangulation/computeMSMS.py
+++ b/masif/source/triangulation/computeMSMS.py
@@ -1,9 +1,10 @@
 import os
 from subprocess import Popen, PIPE
+import sys
 
 from input_output.read_msms import read_msms
 from triangulation.xyzrn import output_pdb_as_xyzrn
-from default_config.global_vars import msms_bin 
+from default_config.global_vars import msms_bin
 from default_config.masif_opts import masif_opts
 import random
 
@@ -39,7 +40,7 @@ def computeMSMS(pdb_file,  protonate=True, keep_hetatms=None):
         fields = line.split()
         areas[fields[3]] = fields[1]
 
-    # Remove temporary files. 
+    # Remove temporary files.
     os.remove(file_base+'.area')
     os.remove(file_base+'.xyzrn')
     os.remove(file_base+'.vert')


### PR DESCRIPTION
Adapt input arguemtns to updated versions of computeMSMS to ensure backward compativility in case someone wants to use the previous way of computing everything (via 01-odb_extract_and_triangulate.py etc.) even if not recommended.